### PR TITLE
Add SkyVector button

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -1056,6 +1056,7 @@ async function start() {
     ['calcBtn', 'click', calculateRoute],
     ['foreflightBtn', 'click', openForeFlight],
     ['weatherBtn', 'click', getWeather],
+    ['skyvectorBtn', 'click', openSkyVector],
     ['emailBtn', 'click', composeEmail],
     ['printBtn', 'click', printFlightLog],
     ['manageBtn', 'click', (e) => (window.location.href = e.target.dataset.href)],

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -172,6 +172,7 @@
       <button id="calcBtn">Calculate Route</button>
       <button id="foreflightBtn">Open Foreflight</button>
       <button id="weatherBtn">Get Weather</button>
+      <button id="skyvectorBtn">Open SkyVector</button>
       <button id="emailBtn">Compose Email</button>
       <button id="printBtn">Print Flight Log</button>
       <button id="manageBtn" data-href="{{ url_for('manage') }}">Manage Data</button>


### PR DESCRIPTION
## Summary
- add a SkyVector button to the index page
- allow opening SkyVector directly from UI by wiring up the button in `script.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c37c2464c832196ef20735aacc827