### PR TITLE
Fix leg table borders

### DIFF
--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -113,6 +113,19 @@ button:hover {
   margin-bottom: 10px;
 }
 
+/* Only show an outer border for leg tables */
+.leg-row table {
+  width: 100%;
+  margin-bottom: 10px;
+  border-collapse: collapse;
+  border: 1px solid #ccc;
+}
+
+.leg-row td {
+  border: none;
+  padding: 10px;
+}
+
 #result {
   margin-top: 20px;
   font-size: 16px;


### PR DESCRIPTION
## Summary
- ensure tables within `.leg-row` only show an outer border

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb74ac0508321b69c4ade12f4b7e8