### PR TITLE
Fix print log when flight number field missing

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -891,7 +891,10 @@ function composeEmail() {
 function printFlightLog() {
   const date = new Date().toLocaleDateString();
   const reg = document.getElementById("helicopter").value || "";
-  const flightNum = document.getElementById("flightNum").value || "";
+  const flightNumInput =
+    document.getElementById("flightNum") ||
+    document.getElementById("flight#");
+  const flightNum = flightNumInput ? flightNumInput.value : "";
   const left = document.getElementById("leftPilot").value || "";
   const right = document.getElementById("rightPilot").value || "";
   const seat1a = document.getElementById("seat1a").value || "";


### PR DESCRIPTION
## Summary
- make printFlightLog compatible with old `flight#` input ID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cbe8d9fa483218429ef96b42ff846