### PR TITLE
Fix HTML layout warnings

### DIFF
--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>Helicopter Route Planner</title>
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Roboto&amp;display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
@@ -83,7 +83,6 @@
 
       <label for="baggage">Baggage</label>
       <input type="number" id="baggage" style="width: 50px" placeholder="(Kg)" />
-    </div>
     
       <label for="speed">Cruise Speed</label>
       <input type="number" id="speed" value="115" style="width: 50px" placeholder="Kt" min="90" max="130" />

--- a/myapp/templates/manage.html
+++ b/myapp/templates/manage.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Manage Data</title>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&amp;display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- clean up index.html layout and escape the fonts URL
- escape URL in manage.html

## Testing
- `pytest -q`
- `tidy -e myapp/templates/index.html`
- `tidy -e myapp/templates/manage.html`


------
https://chatgpt.com/codex/tasks/task_e_687cc6d55c2083219a3762bb3cd8545c