### PR TITLE
Add full route link in email

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -908,6 +908,8 @@ function composeEmail() {
     const endWp = points[points.length - 1].original || "";
     const subjectStr = `Flight #${flightNum} ${startWp} to ${endWp}`;
     const subject = encodeURIComponent(subjectStr);
+    const fullRoute = points.map(formatForForeFlight).join("+");
+    const fullForeflightURL = `foreflightmobile://maps/search?q=${fullRoute}`;
     const bodyHTML =
       "Here are the route planner links:" +
       "\n\n" +
@@ -915,6 +917,8 @@ function composeEmail() {
       foreflightURLs
         .map((url, i) => `<a href=\"${url}\">Leg ${i + 1}</a>`)
         .join("\n") +
+      "\n" +
+      `ForeFlight (Entire Route):\n<a href=\"${fullForeflightURL}\">Full Route</a>` +
       "\n\n" +
       `Windy:\n<a href=\"${windyURL}\">${windyURL}</a>\n\n` +
       `METAR-TAF:\n<a href=\"${metarURL}\">${metarURL}</a>\n\n` +


### PR DESCRIPTION
## Summary
- add a ForeFlight link for the entire route in email composition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd0d6b1a483219f5d03cbed5c3561