### PR TITLE
Remove fuel uplift in remarks

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -978,9 +978,7 @@ function printFlightLog() {
     const fuelUpliftVal = leg.fuelUp;
     const litres = fuelUpliftVal ? Math.round(fuelUpliftVal / 0.8) : "";
     const fuelUplift = fuelUpliftVal ? fuelUpliftVal : "&nbsp;";
-    const remarks = fuelUpliftVal
-      ? `${fuelUpliftVal}kg/${litres}litres`
-      : "";
+    const remarks = "";
     legRows += `<tr><td>${i + 1}</td>
       <td>${leg.from}</td>
       <td>${leg.to}</td>


### PR DESCRIPTION
## Summary
- keep print log remarks empty

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d995340ec832198add9fb40aea273