### PR TITLE
Clean up table styling

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -384,7 +384,7 @@ function addLeg() {
   const newRow = document.createElement("div");
   newRow.className = "leg-row";
   newRow.innerHTML = `
-    <table style="width: 100%; margin-bottom: 10px;">
+    <table class="leg-table">
       <tr>
         <td>
           <label>Leg ${legCount}:</label>
@@ -409,11 +409,11 @@ function addLeg() {
         </td>
       </tr>
       <tr>
-        <td style="padding-left: 20px;">
+        <td class="leg-options">
           <label><input type="checkbox" class="patient-checkbox"> Patient</label>
           <label><input type="checkbox" class="escort-checkbox"> Escort</label>
           <label>Fuel Uplift</label>
-          <input type="number" class="legfuel" style="width: 50px;" min="100" max="904" placeholder="(Kg)">
+          <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)">
         </td>
       </tr>
     </table>

--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -113,17 +113,25 @@ button:hover {
   margin-bottom: 10px;
 }
 
-/* Only show an outer border for leg tables */
-.leg-row table {
+/* Styling for the leg entry tables */
+.leg-table {
   width: 100%;
   margin-bottom: 10px;
   border-collapse: collapse;
   border: 1px solid #ccc;
 }
 
-.leg-row td {
+.leg-table td {
   border: none;
   padding: 10px;
+}
+
+.leg-options {
+  padding-left: 20px;
+}
+
+.legfuel {
+  width: 50px;
 }
 
 #result {

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -107,7 +107,7 @@
     <!-- Route Legs -->
     <div id="legs">
       <div class="leg-row">
-        <table style="width: 100%; margin-bottom: 10px">
+        <table class="leg-table">
           <tr>
             <td>
               <label>Leg 1:</label>
@@ -162,7 +162,7 @@
             </td>
           </tr>
           <tr>
-            <td style="padding-left: 20px">
+            <td class="leg-options">
               <label
                 ><input type="checkbox" class="patient-checkbox" />
                 Patient</label
@@ -171,7 +171,7 @@
                 ><input type="checkbox" class="escort-checkbox" /> Escort</label
               >
               <label>Fuel Uplift</label>
-              <input type="number" class="legfuel" style="width: 50px" min="100" max="904" placeholder="(Kg)"/>
+              <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)" />
             </td>
           </tr>
         </table>


### PR DESCRIPTION
## Summary
- use CSS classes instead of inline styles for leg table
- add leg-table related rules in stylesheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da63e28088321a05e2fba1f35807f