### PR TITLE
Fix fuel input width for added legs

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -413,7 +413,7 @@ function addLeg() {
           <label><input type="checkbox" class="patient-checkbox"> Patient</label>
           <label><input type="checkbox" class="escort-checkbox"> Escort</label>
           <label>Fuel Uplift</label>
-          <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)">
+          <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)" style="width: 50px">
         </td>
       </tr>
     </table>

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -171,7 +171,7 @@
                 ><input type="checkbox" class="escort-checkbox" /> Escort</label
               >
               <label>Fuel Uplift</label>
-              <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)" />
+              <input type="number" class="legfuel" min="100" max="904" placeholder="(Kg)" style="width: 50px" />
             </td>
           </tr>
         </table>


### PR DESCRIPTION
## Summary
- set a fixed width on the fuel uplift field in the template
- ensure dynamically created legs apply the same width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da8cbed788321b9739a8d4baefebe