### PR TITLE
Add PDF download button

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -928,7 +928,7 @@ function composeEmail() {
     console.error(err);
   }
 }
-function printFlightLog() {
+function buildFlightLogHTML() {
   const date = new Date().toLocaleDateString();
   const reg = document.getElementById("helicopter").value || "";
   const flightNumInput =
@@ -1103,10 +1103,30 @@ function printFlightLog() {
       ${weightSection}
       ${routeSection}
     </div>`;
+  return html;
+}
+
+function printFlightLog() {
+  const html = buildFlightLogHTML();
   const win = window.open("", "_blank");
   win.document.write(html);
   win.document.close();
   win.print();
+}
+
+function downloadFlightPlan() {
+  const html = buildFlightLogHTML();
+  if (window.jspdf && window.jspdf.jsPDF) {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+    doc.html(html, {
+      callback: (doc) => doc.save('flight_plan.pdf'),
+      x: 10,
+      y: 10,
+    });
+  } else {
+    alert('Unable to load PDF library');
+  }
 }
 async function start() {
   await fetchData();
@@ -1128,6 +1148,7 @@ async function start() {
     ['weatherBtn', 'click', getWeather],
     ['skyvectorBtn', 'click', openSkyVector],
     ['emailBtn', 'click', composeEmail],
+    ['downloadBtn', 'click', downloadFlightPlan],
     ['printBtn', 'click', printFlightLog],
     ['manageBtn', 'click', (e) => (window.location.href = e.target.dataset.href)],
     ['region-select', 'change', populateAllDropdowns],

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -184,6 +184,7 @@
       <button id="weatherBtn">Get Weather</button>
       <button id="skyvectorBtn">Open SkyVector</button>
       <button id="emailBtn">Compose Email</button>
+      <button id="downloadBtn">Download Flt Plan</button>
       <button id="printBtn">Print Flight Log</button>
       <button id="manageBtn" data-href="{{ url_for('manage') }}">Manage Data</button>
 
@@ -192,6 +193,7 @@
       <div id="errors" style="color: red"></div>
 
       <script src="{{ url_for('static', filename='suncalc.js') }}"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
       <script src="{{ url_for('static', filename='script.js') }}"></script>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add Download Flight Plan button on the main page
- load jsPDF from CDN
- generate flight plan PDF in browser

## Testing
- `pip install -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1ca35e50832196fc08bcacbca4b6