### PR TITLE
Fix print landscape orientation

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -1048,9 +1048,11 @@ function printFlightLog() {
 
   const html = `
     <style type="text/css">
-    @page {
-  size: landscape;
-}
+    @media print {
+      @page {
+        size: landscape;
+      }
+    }
       table.tableizer-table {
       font-size: 8px; border:
       1px solid #CCC;


### PR DESCRIPTION
## Summary
- print flight log in landscape by wrapping `@page` with `@media print`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e22128e548321ac35333f524b7913