### PR TITLE
Allow per-table font sizes

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -1054,60 +1054,25 @@ function printFlightLog() {
       </tbody>
     </table>`;
 
+  const rootStyles = getComputedStyle(document.documentElement);
+  const routeFontSize = rootStyles.getPropertyValue("--route-table-font-size").trim();
+  const weightFontSize = rootStyles.getPropertyValue("--weight-table-font-size").trim();
+  const infoFontSize = rootStyles.getPropertyValue("--info-table-font-size").trim();
+  const legsFontSize = rootStyles.getPropertyValue("--legs-table-font-size").trim();
+
   const html = `
+    <link rel="stylesheet" href="/static/style.css">
     <style type="text/css">
     @media print {
       @page {
         size: landscape;
       }
     }
-      table.tableizer-table {
-      font-size: 8px; border:
-      1px solid #CCC;
-      font-family: "Roboto", Arial, Helvetica, sans-serif;
-      table-layout: auto;
-      border-collapse: collapse;
-      border-spacing: 0;
-      }
-      .tableizer-table th,
-      .tableizer-table td {
-        border: 1px solid #000;
-        padding: 4px;
-        margin: 0;
-        font-weight: normal !important;
-      }
-    .tableizer-table th {
-      background-color: #FFF;
-      color:           #000;
-    }
-    .spacer {
-      border: none;
-      visibility: hidden;
-      padding: 0;
-    }
-    .print-row {
-      display: flex;
-      gap: 0;
-      align-items: flex-start;
-    }
-    .route-section { flex: 2; }
-    .weight-section { flex: 1; }
-    .weight-table {
-      font-size: 15px;
-      width: auto;
-      margin: 0;
-    }
-    .weight-table th,
-    .weight-table td {
-      padding: 4px;
-    }
-    .weight-table th:first-child,
-    .weight-table td:first-child {
-      width: 20px;
-    }
-    .weight-table th:not(:first-child),
-    .weight-table td:not(:first-child) {
-      width: 35px;
+    :root {
+      --route-table-font-size: ${routeFontSize};
+      --weight-table-font-size: ${weightFontSize};
+      --info-table-font-size: ${infoFontSize};
+      --legs-table-font-size: ${legsFontSize};
     }
     </style>
     ${infoTable}

--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -1,3 +1,10 @@
+:root {
+  --route-table-font-size: 8px;
+  --weight-table-font-size: 10px;
+  --info-table-font-size: 8px;
+  --legs-table-font-size: 8px;
+}
+
 body {
   font-family: "Roboto", sans-serif;
   font-size: 16px;
@@ -168,7 +175,7 @@ th {
 /* Generated Weight Table Styles */
 /* ============================= */
 #weightTable table.weight-table {
-  font-size: 10px; /* make leg weight table more compact */
+  font-size: var(--weight-table-font-size); /* make leg weight table more compact */
   width: auto; /* override global 95% width */
 }
 
@@ -213,7 +220,7 @@ th {
 }
 
 .weight-section .weight-table {
-  font-size: 15px;
+  font-size: var(--weight-table-font-size);
   width: auto;
   margin: 0;
 }
@@ -237,7 +244,6 @@ th {
 /* Route & Print Table Styles */
 /* ============================= */
 table.tableizer-table {
-  font-size: 8px;
   border: 1px solid #ccc;
   font-family: "Roboto", Arial, Helvetica, sans-serif;
   table-layout: fixed;
@@ -260,6 +266,18 @@ table.tableizer-table {
   color: #000;
 }
 
+.route-table {
+  font-size: var(--route-table-font-size);
+}
+.weight-table {
+  font-size: var(--weight-table-font-size);
+}
+.info-table {
+  font-size: var(--info-table-font-size);
+}
+.legs-table {
+  font-size: var(--legs-table-font-size);
+}
 .spacer {
   border: none;
   visibility: hidden;


### PR DESCRIPTION
## Summary
- introduce CSS variables for table font sizes
- style each table class using the new variables
- sync print view with per-table font sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4711f1488321a248db162cd6eb82