### PR TITLE
Add spacing between print sections

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -1092,7 +1092,7 @@ function printFlightLog() {
     }
     .print-row {
       display: flex;
-      gap: 0;
+      gap: 12px;
       align-items: flex-start;
     }
     .route-section { flex: 2; }
@@ -1120,7 +1120,7 @@ function printFlightLog() {
     </style>
     ${infoTable}
     ${legsTable}
-    <div class="print-row">
+    <div style="margin-top: 12px;" class="print-row">
       ${weightSection}
       ${routeSection}
     </div>`;

--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -207,7 +207,7 @@ th {
 
 .print-row {
   display: flex;
-  gap: 0;
+  gap: 12px;
   align-items: flex-start;
 }
 


### PR DESCRIPTION
## Summary
- add gap between the weight and route sections in print layout
- include `margin-top` when generating the print HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6d83ffc08321b5107f159042b878