### PR TITLE
Use Blueprints

### DIFF
--- a/myapp/data_utils.py
+++ b/myapp/data_utils.py
@@ -1,0 +1,49 @@
+import os
+import json
+import tempfile
+
+DATA_FILE = os.environ.get('DATA_FILE', os.path.join(os.path.dirname(__file__), 'data.json'))
+
+DEFAULT_DATA = {
+    'HELICOPTERS': [],
+    'PILOTS': [],
+    'MEDICS': [],
+    'waypoints': {},
+    'MAX_FUEL': 0,
+    'MIN_FUEL': 0,
+    'MAX_TAKEOFF_WEIGHT': 0,
+}
+
+
+def load_data():
+    """Load the shared JSON data file or initialize it if missing."""
+    if not os.path.exists(DATA_FILE):
+        save_data(DEFAULT_DATA)
+    try:
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        save_data(DEFAULT_DATA)
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+
+
+def save_data(data):
+    """Atomically save the shared JSON data file."""
+    directory = os.path.dirname(DATA_FILE)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=directory)
+    with os.fdopen(fd, 'w') as tmp:
+        json.dump(data, tmp, indent=2)
+    os.replace(tmp_path, DATA_FILE)
+
+
+def add_entry(section, item, code=None):
+    data = load_data()
+    if section == 'waypoints':
+        if not code:
+            raise ValueError('Waypoint code required')
+        data['waypoints'][code] = item
+    else:
+        data[section].append(item)
+    save_data(data)

--- a/myapp/medic.py
+++ b/myapp/medic.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, request, jsonify
+
+from .data_utils import load_data, add_entry
+
+medic_bp = Blueprint('medic_bp', __name__)
+
+
+@medic_bp.route('/addMedic', methods=['POST'])
+def add_medic():
+    payload = request.get_json(force=True)
+    name = (payload.get('name') or '').strip()
+    weight = payload.get('weight')
+    if not name or weight is None:
+        return jsonify({'error': 'Invalid data'}), 400
+    data = load_data()
+    if any(m.get('name', '').lower() == name.lower() for m in data.get('MEDICS', [])):
+        return jsonify({'error': 'Medic already exists'}), 400
+    add_entry('MEDICS', {'name': name, 'weight': weight})
+    return jsonify({'status': 'ok'})

--- a/myapp/pilot.py
+++ b/myapp/pilot.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, request, jsonify
+
+from .data_utils import load_data, add_entry
+
+pilot_bp = Blueprint('pilot_bp', __name__)
+
+
+@pilot_bp.route('/addPilot', methods=['POST'])
+def add_pilot():
+    payload = request.get_json(force=True)
+    name = (payload.get('name') or '').strip()
+    weight = payload.get('weight')
+    if not name or weight is None:
+        return jsonify({'error': 'Invalid data'}), 400
+    data = load_data()
+    if any(p.get('name', '').lower() == name.lower() for p in data.get('PILOTS', [])):
+        return jsonify({'error': 'Pilot already exists'}), 400
+    add_entry('PILOTS', {'name': name, 'weight': weight})
+    return jsonify({'status': 'ok'})

--- a/myapp/waypoint.py
+++ b/myapp/waypoint.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, request, jsonify
+
+from .data_utils import load_data, add_entry
+
+waypoint_bp = Blueprint('waypoint_bp', __name__)
+
+
+@waypoint_bp.route('/addWaypoint', methods=['POST'])
+def add_waypoint():
+    payload = request.get_json(force=True)
+    code = (payload.get('code') or '').strip().upper()
+    name = (payload.get('name') or '').strip()
+    regions = payload.get('regions') or []
+    lat = payload.get('lat')
+    lon = payload.get('lon')
+    if not code or not name or not regions or lat is None or lon is None:
+        return jsonify({'error': 'Invalid data'}), 400
+    data = load_data()
+    if code in data.get('waypoints', {}):
+        return jsonify({'error': 'Waypoint already exists'}), 400
+    waypoint = {
+        'name': name,
+        'regions': regions,
+        'lat': lat,
+        'lon': lon,
+    }
+    add_entry('waypoints', waypoint, code=code)
+    return jsonify({'status': 'ok'})


### PR DESCRIPTION
## Summary
- split route logic into pilot, medic and waypoint blueprints
- centralize JSON data helpers in `data_utils.py`
- register the blueprints in `app.py`

## Testing
- `pip install -q -r myapp/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e788a5dec8321ad986e4646ac3171