### PR TITLE
Support waypoint elevation in route table

### DIFF
--- a/myapp/data.json
+++ b/myapp/data.json
@@ -28,7 +28,8 @@
         "ALL"
       ],
       "lat": 49.0361,
-      "lon": -122.3141
+      "lon": -122.3141,
+      "elev": 0
     },
     "CYXX": {
       "name": "Abbotsford",
@@ -37,7 +38,8 @@
         "ALL"
       ],
       "lat": 49.0253,
-      "lon": -122.36
+      "lon": -122.36,
+      "elev": 0
     },
     "BIS": {
       "name": "Bowen Island",
@@ -46,7 +48,8 @@
         "ALL"
       ],
       "lat": 49.3775,
-      "lon": -123.335
+      "lon": -123.335,
+      "elev": 0
     },
     "BIG": {
       "name": "Bowen Island (Golf)",
@@ -55,7 +58,8 @@
         "ALL"
       ],
       "lat": 49.3408,
-      "lon": -123.3605
+      "lon": -123.3605,
+      "elev": 0
     },
     "CFR6": {
       "name": "Coquitlam Fire & Rescue",
@@ -64,7 +68,8 @@
         "ALL"
       ],
       "lat": 49.2916,
-      "lon": -122.7922
+      "lon": -122.7922,
+      "elev": 0
     },
     "CBL7": {
       "name": "Cortes Island",
@@ -74,7 +79,8 @@
         "ALL"
       ],
       "lat": 50.0586,
-      "lon": -124.982
+      "lon": -124.982,
+      "elev": 0
     },
     "CAK3": {
       "name": "Delta Heritage",
@@ -83,7 +89,8 @@
         "ALL"
       ],
       "lat": 49.0781,
-      "lon": -122.9381
+      "lon": -122.9381,
+      "elev": 0
     },
     "CAF6": {
       "name": "Big Bay",
@@ -93,7 +100,8 @@
         "ALL"
       ],
       "lat": 50.3921,
-      "lon": -125.1369
+      "lon": -125.1369,
+      "elev": 0
     },
     "CAG6": {
       "name": "Blind Channel",
@@ -103,7 +111,8 @@
         "ALL"
       ],
       "lat": 50.4132,
-      "lon": -125.5017
+      "lon": -125.5017,
+      "elev": 0
     },
     "CAP3": {
       "name": "Sechelt",
@@ -112,7 +121,8 @@
         "ALL"
       ],
       "lat": 49.4603,
-      "lon": -123.7168
+      "lon": -123.7168,
+      "elev": 0
     },
     "CYNJ": {
       "name": "Langley",
@@ -121,7 +131,8 @@
         "ALL"
       ],
       "lat": 49.1008,
-      "lon": -122.6306
+      "lon": -122.6306,
+      "elev": 0
     },
     "CZBB": {
       "name": "Boundary Bay",
@@ -130,7 +141,8 @@
         "ALL"
       ],
       "lat": 49.0779,
-      "lon": -123.0071
+      "lon": -123.0071,
+      "elev": 0
     },
     "CYVR": {
       "name": "Vancouver",
@@ -139,7 +151,8 @@
         "ALL"
       ],
       "lat": 49.1939,
-      "lon": -123.1833
+      "lon": -123.1833,
+      "elev": 0
     },
     "CBC7": {
       "name": "Vancouver Harbour Heliport",
@@ -148,7 +161,8 @@
         "ALL"
       ],
       "lat": 49.2869,
-      "lon": -123.1061
+      "lon": -123.1061,
+      "elev": 0
     },
     "CYPK": {
       "name": "Pitt Meadows",
@@ -157,7 +171,8 @@
         "ALL"
       ],
       "lat": 49.2161,
-      "lon": -122.7086
+      "lon": -122.7086,
+      "elev": 0
     },
     "CAT6": {
       "name": "Campbell River Hospital",
@@ -166,7 +181,8 @@
         "ALL"
       ],
       "lat": 50.0086,
-      "lon": -125.2427
+      "lon": -125.2427,
+      "elev": 0
     },
     "CYAL": {
       "name": "Alert Bay",
@@ -175,7 +191,8 @@
         "ALL"
       ],
       "lat": 50.5822,
-      "lon": -126.9158
+      "lon": -126.9158,
+      "elev": 0
     },
     "CAH3": {
       "name": "Courtenay Airpark",
@@ -184,7 +201,8 @@
         "ALL"
       ],
       "lat": 49.6794,
-      "lon": -124.9816
+      "lon": -124.9816,
+      "elev": 0
     },
     "WCR": {
       "name": "Campbell River SPIT",
@@ -193,7 +211,8 @@
         "ALL"
       ],
       "lat": 50.0452,
-      "lon": -125.2536
+      "lon": -125.2536,
+      "elev": 0
     },
     "CBV8": {
       "name": "Comox Valley Hospital",
@@ -202,7 +221,8 @@
         "ALL"
       ],
       "lat": 49.7122,
-      "lon": -124.9694
+      "lon": -124.9694,
+      "elev": 0
     },
     "BAP": {
       "name": "Bamfield",
@@ -211,7 +231,8 @@
         "ALL"
       ],
       "lat": 48.8227,
-      "lon": -125.1177
+      "lon": -125.1177,
+      "elev": 0
     },
     "CWS": {
       "name": "Chemainus",
@@ -220,7 +241,8 @@
         "ALL"
       ],
       "lat": 48.9183,
-      "lon": -123.7106
+      "lon": -123.7106,
+      "elev": 0
     },
     "CDD": {
       "name": "Colwood DND",
@@ -229,7 +251,8 @@
         "ALL"
       ],
       "lat": 48.4481,
-      "lon": -123.4541
+      "lon": -123.4541,
+      "elev": 0
     },
     "CYCD": {
       "name": "Nanaimo",
@@ -238,7 +261,8 @@
         "ALL"
       ],
       "lat": 49.0556,
-      "lon": -123.8697
+      "lon": -123.8697,
+      "elev": 0
     },
     "CYAZ": {
       "name": "Tofino",
@@ -247,7 +271,8 @@
         "ALL"
       ],
       "lat": 49.0759,
-      "lon": -125.77
+      "lon": -125.77,
+      "elev": 0
     },
     "CYWH": {
       "name": "Victoria Inner Harbour",
@@ -256,7 +281,8 @@
         "ALL"
       ],
       "lat": 48.4308,
-      "lon": -123.4317
+      "lon": -123.4317,
+      "elev": 0
     },
     "CYYJ": {
       "name": "Victoria International",
@@ -265,7 +291,8 @@
         "ALL"
       ],
       "lat": 48.6469,
-      "lon": -123.4269
+      "lon": -123.4269,
+      "elev": 0
     },
     "CAT4": {
       "name": "Qualicum",
@@ -274,7 +301,8 @@
         "ALL"
       ],
       "lat": 49.3394,
-      "lon": -124.3965
+      "lon": -124.3965,
+      "elev": 0
     },
     "AHL": {
       "name": "Ashcroft Hospital",
@@ -283,7 +311,8 @@
         "ALL"
       ],
       "lat": 50.735,
-      "lon": -121.281
+      "lon": -121.281,
+      "elev": 0
     },
     "CYYF": {
       "name": "Penticton",
@@ -292,7 +321,8 @@
         "ALL"
       ],
       "lat": 49.4631,
-      "lon": -119.6017
+      "lon": -119.6017,
+      "elev": 0
     },
     "CQV3": {
       "name": "Queen Victoria",
@@ -301,7 +331,8 @@
         "ALL"
       ],
       "lat": 50.9776,
-      "lon": -118.1893
+      "lon": -118.1893,
+      "elev": 0
     },
     "CYLW": {
       "name": "Kelowna International",
@@ -310,7 +341,8 @@
         "ALL"
       ],
       "lat": 49.9561,
-      "lon": -119.3772
+      "lon": -119.3772,
+      "elev": 0
     },
     "CYCG": {
       "name": "West Kootenay Regional",
@@ -319,7 +351,8 @@
         "ALL"
       ],
       "lat": 49.2964,
-      "lon": -117.6325
+      "lon": -117.6325,
+      "elev": 0
     },
     "CAJ4": {
       "name": "Anahim Lake",
@@ -328,7 +361,8 @@
         "ALL"
       ],
       "lat": 52.4516,
-      "lon": -125.305
+      "lon": -125.305,
+      "elev": 0
     },
     "CAV3": {
       "name": "100 Mile House",
@@ -337,7 +371,8 @@
         "ALL"
       ],
       "lat": 51.6433,
-      "lon": -121.3066
+      "lon": -121.3066,
+      "elev": 0
     },
     "CYBD": {
       "name": "Bella Coola Heliport",
@@ -346,7 +381,8 @@
         "ALL"
       ],
       "lat": 52.3875,
-      "lon": -126.5958
+      "lon": -126.5958,
+      "elev": 0
     },
     "CYPZ": {
       "name": "Burns Lake",
@@ -355,7 +391,8 @@
         "ALL"
       ],
       "lat": 54.3772,
-      "lon": -125.9526
+      "lon": -125.9526,
+      "elev": 0
     },
     "CYJM": {
       "name": "Fort St James",
@@ -364,7 +401,8 @@
         "ALL"
       ],
       "lat": 54.3966,
-      "lon": -124.2633
+      "lon": -124.2633,
+      "elev": 0
     },
     "CBZ9": {
       "name": "Fraser Lake",
@@ -373,7 +411,8 @@
         "ALL"
       ],
       "lat": 54.0133,
-      "lon": -124.7683
+      "lon": -124.7683,
+      "elev": 0
     },
     "CYZY": {
       "name": "Mackenzie",
@@ -382,7 +421,8 @@
         "ALL"
       ],
       "lat": 55.2994,
-      "lon": -123.1333
+      "lon": -123.1333,
+      "elev": 0
     },
     "CAV4": {
       "name": "McBride",
@@ -391,7 +431,8 @@
         "ALL"
       ],
       "lat": 53.315,
-      "lon": -120.17
+      "lon": -120.17,
+      "elev": 0
     },
     "CYXT": {
       "name": "Northwest Terrace",
@@ -400,7 +441,8 @@
         "ALL"
       ],
       "lat": 54.4685,
-      "lon": -128.5762
+      "lon": -128.5762,
+      "elev": 0
     },
     "CBN9": {
       "name": "Tsay Keh",
@@ -409,7 +451,8 @@
         "ALL"
       ],
       "lat": 56.9066,
-      "lon": -124.9666
+      "lon": -124.9666,
+      "elev": 0
     },
     "CBX7": {
       "name": "Tumbler Ridge",
@@ -418,7 +461,8 @@
         "ALL"
       ],
       "lat": 55.0266,
-      "lon": -120.9316
+      "lon": -120.9316,
+      "elev": 0
     },
     "CAU4": {
       "name": "Vanderhoof",
@@ -427,7 +471,8 @@
         "ALL"
       ],
       "lat": 54.0466,
-      "lon": -124.0116
+      "lon": -124.0116,
+      "elev": 0
     },
     "CYXS": {
       "name": "Prince George",
@@ -436,7 +481,8 @@
         "ALL"
       ],
       "lat": 53.8833,
-      "lon": -122.6783
+      "lon": -122.6783,
+      "elev": 0
     },
     "CYYD": {
       "name": "Smithers",
@@ -445,7 +491,8 @@
         "ALL"
       ],
       "lat": 54.8247,
-      "lon": -127.1828
+      "lon": -127.1828,
+      "elev": 0
     },
     "CYZP": {
       "name": "Sandspit",
@@ -454,7 +501,8 @@
         "ALL"
       ],
       "lat": 53.2543,
-      "lon": -131.8138
+      "lon": -131.8138,
+      "elev": 0
     }
   },
   "PILOTS": [

--- a/myapp/static/manage.js
+++ b/myapp/static/manage.js
@@ -61,19 +61,21 @@ function addWaypoint() {
   const regionText = document.getElementById('waypointRegion').value.trim();
   const lat = parseFloat(document.getElementById('waypointLat').value);
   const lon = parseFloat(document.getElementById('waypointLon').value);
-  if (!code || !name || !regionText || isNaN(lat) || isNaN(lon)) {
+  const elev = parseFloat(document.getElementById('waypointElev').value);
+  if (!code || !name || !regionText || isNaN(lat) || isNaN(lon) || isNaN(elev)) {
     alert('Please fill out all waypoint fields');
     return;
   }
   const regions = regionText.split(',').map(r => r.trim());
-  postData('/addWaypoint', { code, name, regions, lat, lon }, () => {
+  postData('/addWaypoint', { code, name, regions, lat, lon, elev }, () => {
     document.getElementById('waypointCode').value = '';
     document.getElementById('waypointName').value = '';
     document.getElementById('waypointRegion').value = '';
     document.getElementById('waypointLat').value = '';
     document.getElementById('waypointLon').value = '';
+    document.getElementById('waypointElev').value = '';
     alert('Waypoint saved');
-    saveExtra('extraWaypoints', { code, name, regions, lat, lon });
+    saveExtra('extraWaypoints', { code, name, regions, lat, lon, elev });
   });
 }
 

--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -646,10 +646,14 @@ function calculateRoute() {
     mins += min;
     totalFuel += legFuel;
     const upliftLitres = fuelUp ? Math.round(fuelUp / 0.8) : "";
+    const destElev =
+      toCode !== "SCENE" && waypoints[toCode] && waypoints[toCode].elev !== undefined
+        ? waypoints[toCode].elev
+        : "";
     table += `<tr>
       <td>${i + 1}</td>
       <td>${fName} ➝ ${tName}</td>
-      <td></td>
+      <td>${destElev}</td>
       <td>${h.toString().padStart(3, "0")}°</td>
       <td>${d}</td>
       <td>${Math.floor(min / 60)}h ${min % 60}m</td>

--- a/myapp/templates/manage.html
+++ b/myapp/templates/manage.html
@@ -39,6 +39,8 @@
       <input id="waypointLat" type="number" step="0.0001" placeholder="Lat" />
       <label for="waypointLon">Lon</label>
       <input id="waypointLon" type="number" step="0.0001" placeholder="Lon" />
+      <label for="waypointElev">Elev</label>
+      <input id="waypointElev" type="number" step="1" placeholder="Elev (ft)" />
       <button id="saveWaypointBtn">Save Waypoint</button>
     </section>
 

--- a/myapp/waypoint.py
+++ b/myapp/waypoint.py
@@ -13,7 +13,8 @@ def add_waypoint():
     regions = payload.get('regions') or []
     lat = payload.get('lat')
     lon = payload.get('lon')
-    if not code or not name or not regions or lat is None or lon is None:
+    elev = payload.get('elev')
+    if not code or not name or not regions or lat is None or lon is None or elev is None:
         return jsonify({'error': 'Invalid data'}), 400
     data = load_data()
     if code in data.get('waypoints', {}):
@@ -23,6 +24,7 @@ def add_waypoint():
         'regions': regions,
         'lat': lat,
         'lon': lon,
+        'elev': elev,
     }
     add_entry('waypoints', waypoint, code=code)
     return jsonify({'status': 'ok'})

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -56,6 +56,7 @@ def test_add_waypoint(client):
         'regions': ['X'],
         'lat': 1.0,
         'lon': 2.0,
+        'elev': 100,
     }
     resp = client.post('/addWaypoint', json=payload)
     assert resp.status_code == 200
@@ -67,3 +68,4 @@ def test_add_waypoint(client):
     assert wp['lat'] == 1.0
     assert wp['lon'] == 2.0
     assert wp['regions'] == ['X']
+    assert wp['elev'] == 100


### PR DESCRIPTION
## Summary
- add elevation column to Manage Waypoint form
- store waypoint elevation in server and JS
- display destination elevation in generated route table
- include elevation when adding a waypoint via API
- adjust tests for new elevation field
- update sample `data.json` with default elevation values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e80d48cd88321a7700d128bc80dd2