### PR TITLE
Reduce gap between leg tables

### DIFF
--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -117,7 +117,7 @@ button:hover {
 }
 
 .leg-row {
-  margin-bottom: 10px;
+  margin-bottom: 2px; /* reduce spacing between leg tables */
 }
 
 /* ============================= */
@@ -125,7 +125,7 @@ button:hover {
 /* ============================= */
 .leg-table {
   width: 80%;
-  margin-bottom: 0px;
+  margin: 0 auto; /* override generic table margin */
   border-collapse: collapse;
   border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- compress spacing between leg tables by overriding global table margin and reducing `.leg-row` margin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e139d7888321b8a8781e2f94b149