### PR TITLE
Add waypoint input highlight on selection

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -234,6 +234,9 @@ function setupWaypointInput(input) {
   };
   input.addEventListener("change", updateCode);
   input.addEventListener("input", () => toggleSceneInputs(input));
+  input.addEventListener("focus", () => {
+    if (input.value) input.select();
+  });
 }
 
 function setupWaypointSearch(input) {
@@ -271,6 +274,8 @@ function setupWaypointSearch(input) {
           code === "SCENE" ? "SCENE" : `${code}-${waypoints[code].name}`;
         hide();
         toggleSceneInputs(input);
+        input.focus();
+        input.select();
       });
       results.appendChild(div);
     });

--- a/myapp/static/style.css
+++ b/myapp/static/style.css
@@ -69,6 +69,10 @@ button {
   display: inline-block;
 }
 
+.waypoint-search input:focus {
+  background-color: #ffffcc;
+}
+
 .waypoint-results {
   display: none;
   position: absolute;


### PR DESCRIPTION
## Summary
- improve waypoint inputs: auto-select text on focus and when choosing a search result
- highlight waypoint inputs when focused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68820af3d0008321a6027621890e80fb