### PR TITLE
Fix pilot selection persistence

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -295,6 +295,7 @@ function setupPilotSearch(id) {
         if (input.value) input.select();
         hide();
         disableDuplicatePilot({ target: input });
+        saveCrewSelection();
       });
       results.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- save pilot selection to localStorage when choosing from autocomplete results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821e8b07bc83219576a64169e8ea02