### PR TITLE
Fix medic selection cache

### DIFF
--- a/myapp/static/script.js
+++ b/myapp/static/script.js
@@ -225,6 +225,7 @@ function setupMedicSearch(id) {
         if (input.value) input.select();
         hide();
         disableDuplicateMedic({ target: input });
+        saveCrewSelection();
       });
       results.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- store medic selection in localStorage when picking from search results

## Testing
- `pip install -r dev-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68821f806e708321b0b62657900dd9ae