### PR TITLE
Fix print window timing

### DIFF
--- a/myapp/static/route.js
+++ b/myapp/static/route.js
@@ -794,6 +794,10 @@ export function printFlightLog() {
   const win = window.open("", "_blank");
   win.document.write(html);
   win.document.close();
-  win.print();
+  if (win.document.readyState === "complete") {
+    win.print();
+  } else {
+    win.addEventListener("load", () => win.print());
+  }
 }
 


### PR DESCRIPTION
## Summary
- ensure the print flight log waits for the new window to finish loading before calling `print()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835309610c83218859a2725ddb8e28