### PR TITLE
Auto-assign waypoint regions

### DIFF
--- a/myapp/static/manage.js
+++ b/myapp/static/manage.js
@@ -25,6 +25,25 @@ function saveExtra(key, item) {
   }
 }
 
+const BASE_COORDS = {
+  Vancouver: { lat: 49.1939, lon: -123.1833 },
+  Parksville: { lat: 49.3129, lon: -124.3686 },
+  Kamloops: { lat: 50.7022, lon: -120.4443 },
+  'Prince George': { lat: 53.8833, lon: -122.6783 },
+  'Prince Rupert': { lat: 54.4685, lon: -128.5762 },
+};
+
+function haversineNM(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const toRad = (x) => (x * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return (R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))) * 0.539957;
+}
+
 function addPilot() {
   const name = document.getElementById('pilotName').value.trim();
   const weight = parseFloat(document.getElementById('pilotWeight').value);
@@ -62,11 +81,17 @@ function addWaypoint() {
   const lat = parseFloat(document.getElementById('waypointLat').value);
   const lon = parseFloat(document.getElementById('waypointLon').value);
   const elev = parseFloat(document.getElementById('waypointElev').value);
-  if (!code || !name || !regionText || isNaN(lat) || isNaN(lon) || isNaN(elev)) {
+  if (!code || !name || isNaN(lat) || isNaN(lon) || isNaN(elev)) {
     alert('Please fill out all waypoint fields');
     return;
   }
-  const regions = regionText.split(',').map(r => r.trim());
+  let regions = regionText ? regionText.split(',').map((r) => r.trim()) : [];
+  if (!regions.includes('ALL')) regions.unshift('ALL');
+  Object.entries(BASE_COORDS).forEach(([base, coords]) => {
+    if (haversineNM(lat, lon, coords.lat, coords.lon) <= 200) {
+      if (!regions.includes(base)) regions.push(base);
+    }
+  });
   postData('/addWaypoint', { code, name, regions, lat, lon, elev }, () => {
     document.getElementById('waypointCode').value = '';
     document.getElementById('waypointName').value = '';

--- a/myapp/templates/manage.html
+++ b/myapp/templates/manage.html
@@ -34,7 +34,7 @@
       <label for="waypointName">Name</label>
       <input id="waypointName" placeholder="Vancouver Int (A)" />
       <label for="waypointRegion">Region(s)</label>
-      <input id="waypointRegion" placeholder="All, Vancouver" />
+      <input id="waypointRegion" placeholder="Extra regions (optional)" />
       <label for="waypointLat">Lat</label>
       <input id="waypointLat" type="number" step="0.0001" placeholder="49.1939" />
       <label for="waypointLon">Lon</label>

--- a/myapp/waypoint.py
+++ b/myapp/waypoint.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify, abort
+import math
 
 try:
     from .data_utils import load_data, add_entry
@@ -7,13 +8,37 @@ except ImportError:
 
 waypoint_bp = Blueprint('waypoint_bp', __name__)
 
+# Coordinates for helicopter bases used for automatic region assignment
+BASE_COORDS = {
+    "Vancouver": {"lat": 49.1939, "lon": -123.1833},
+    "Parksville": {"lat": 49.3129, "lon": -124.3686},
+    "Kamloops": {"lat": 50.7022, "lon": -120.4443},
+    "Prince George": {"lat": 53.8833, "lon": -122.6783},
+    "Prince Rupert": {"lat": 54.4685, "lon": -128.5762},
+}
+
+
+def haversine_nm(lat1, lon1, lat2, lon2):
+    """Return distance between two lat/lon pairs in nautical miles."""
+    R = 6371  # Earth radius in km
+    d_lat = math.radians(lat2 - lat1)
+    d_lon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(d_lon / 2) ** 2
+    )
+    km = 2 * R * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return km * 0.539957  # convert km to nautical miles
+
 
 @waypoint_bp.route('/addWaypoint', methods=['POST'])
 def add_waypoint():
     payload = request.get_json(force=True)
     code = (payload.get('code') or '').strip().upper()
     name = (payload.get('name') or '').strip()
-    regions = payload.get('regions') or []
+    user_regions = payload.get('regions') or []
     lat = payload.get('lat')
     lon = payload.get('lon')
     elev = payload.get('elev')
@@ -25,7 +50,7 @@ def add_waypoint():
     except (TypeError, ValueError):
         abort(400, description='Invalid numeric values')
 
-    if not code or not name or not regions:
+    if not code or not name:
         abort(400, description='Missing required fields')
     if not (-90 <= lat <= 90 and -180 <= lon <= 180):
         abort(400, description='Coordinates out of range')
@@ -35,6 +60,15 @@ def add_waypoint():
     data = load_data()
     if code in data.get('waypoints', {}):
         abort(409, description='Waypoint already exists')
+
+    # Determine regions automatically based on proximity to bases
+    regions = [r for r in user_regions if r]
+    if 'ALL' not in regions:
+        regions.insert(0, 'ALL')
+    for base, coords in BASE_COORDS.items():
+        if haversine_nm(lat, lon, coords['lat'], coords['lon']) <= 200:
+            if base not in regions:
+                regions.append(base)
 
     waypoint = {
         'name': name,

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -53,9 +53,8 @@ def test_add_waypoint(client):
     payload = {
         'code': 'TEST',
         'name': 'Test Point',
-        'regions': ['X'],
-        'lat': 1.0,
-        'lon': 2.0,
+        'lat': 49.2,
+        'lon': -123.1,
         'elev': 100,
     }
     resp = client.post('/addWaypoint', json=payload)
@@ -65,9 +64,10 @@ def test_add_waypoint(client):
     assert payload['code'] in data['waypoints']
     wp = data['waypoints'][payload['code']]
     assert wp['name'] == 'Test Point'
-    assert wp['lat'] == 1.0
-    assert wp['lon'] == 2.0
-    assert wp['regions'] == ['X']
+    assert wp['lat'] == 49.2
+    assert wp['lon'] == -123.1
+    for region in ['ALL', 'Vancouver', 'Parksville', 'Kamloops']:
+        assert region in wp['regions']
     assert wp['elev'] == 100
 
 
@@ -87,7 +87,6 @@ def test_add_waypoint_invalid_lat(client):
     payload = {
         'code': 'BAD',
         'name': 'Bad Point',
-        'regions': ['X'],
         'lat': 95.0,
         'lon': 0.0,
         'elev': 10,


### PR DESCRIPTION
## Summary
- assign waypoint regions automatically based on proximity to base locations
- compute same logic in management UI and make region entry optional
- adjust manage page hint text
- update tests for new behavior

## Testing
- `pip install -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835c36208c832198cc496286f9415a