### PR TITLE
Add BC coordinate checks

### DIFF
--- a/myapp/static/manage.js
+++ b/myapp/static/manage.js
@@ -33,6 +33,13 @@ const BASE_COORDS = {
   'Prince Rupert': { lat: 54.4685, lon: -128.5762 },
 };
 
+const BC_BOUNDS = {
+  minLat: 48.3,
+  maxLat: 60.0,
+  minLon: -139.1,
+  maxLon: -114.0,
+};
+
 function haversineNM(lat1, lon1, lat2, lon2) {
   const R = 6371;
   const toRad = (x) => (x * Math.PI) / 180;
@@ -83,6 +90,15 @@ function addWaypoint() {
   const elev = parseFloat(document.getElementById('waypointElev').value);
   if (!code || !name || isNaN(lat) || isNaN(lon) || isNaN(elev)) {
     alert('Please fill out all waypoint fields');
+    return;
+  }
+  if (
+    lat < BC_BOUNDS.minLat ||
+    lat > BC_BOUNDS.maxLat ||
+    lon < BC_BOUNDS.minLon ||
+    lon > BC_BOUNDS.maxLon
+  ) {
+    alert('Coordinates must be within British Columbia');
     return;
   }
   let regions = regionText ? regionText.split(',').map((r) => r.trim()) : [];

--- a/myapp/static/route.js
+++ b/myapp/static/route.js
@@ -1,4 +1,11 @@
 import { waypoints, PILOTS, MEDICS, HELICOPTERS, MIN_FUEL, MAX_FUEL, MAX_TAKEOFF_WEIGHT, BASE_COORDS } from "./data.js";
+
+export const BC_BOUNDS = {
+  minLat: 48.3,
+  maxLat: 60.0,
+  minLon: -139.1,
+  maxLon: -114.0,
+};
 export let latestLegWeights = [];
 export let latestWeightTable = "";
 export let latestRouteTable = "";
@@ -12,6 +19,15 @@ export function haversine(lat1, lon1, lat2, lon2) {
     Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
   return Math.round(
     R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)) * 0.539957,
+  );
+}
+
+export function withinBC(lat, lon) {
+  return (
+    lat >= BC_BOUNDS.minLat &&
+    lat <= BC_BOUNDS.maxLat &&
+    lon >= BC_BOUNDS.minLon &&
+    lon <= BC_BOUNDS.maxLon
   );
 }
 export function calculateRoute() {
@@ -145,6 +161,10 @@ export function calculateRoute() {
       if (fromCode === "SCENE") {
         fLat = parseFloat(leg.querySelector(".from-lat").value);
         fLon = parseFloat(leg.querySelector(".from-lon").value);
+        if (!withinBC(fLat, fLon)) {
+          alert(`Scene coordinates on leg ${i + 1} must be within British Columbia`);
+          errors.push(`Scene coordinates on leg ${i + 1} must be within British Columbia`);
+        }
         fName = `SCENE (${fLat}, ${fLon})`;
       } else {
         const f = waypoints[fromCode];
@@ -155,6 +175,10 @@ export function calculateRoute() {
       if (toCode === "SCENE") {
         tLat = parseFloat(leg.querySelector(".to-lat").value);
         tLon = parseFloat(leg.querySelector(".to-lon").value);
+        if (!withinBC(tLat, tLon)) {
+          alert(`Scene coordinates on leg ${i + 1} must be within British Columbia`);
+          errors.push(`Scene coordinates on leg ${i + 1} must be within British Columbia`);
+        }
         tName = `SCENE (${tLat}, ${tLon})`;
       } else {
         const t = waypoints[toCode];
@@ -340,6 +364,9 @@ export function getPoints() {
       const lon = parseFloat(lonInput.value);
       if (isNaN(lat) || isNaN(lon)) {
         throw new Error("Scene latitude and longitude are required");
+      }
+      if (!withinBC(lat, lon)) {
+        throw new Error("Scene coordinates must be within British Columbia");
       }
       return { lat, lon, original: code };
     }

--- a/myapp/waypoint.py
+++ b/myapp/waypoint.py
@@ -17,6 +17,14 @@ BASE_COORDS = {
     "Prince Rupert": {"lat": 54.4685, "lon": -128.5762},
 }
 
+# Bounding box for British Columbia (approximate)
+BC_BOUNDS = {
+    "min_lat": 48.3,
+    "max_lat": 60.0,
+    "min_lon": -139.1,
+    "max_lon": -114.0,
+}
+
 
 def haversine_nm(lat1, lon1, lat2, lon2):
     """Return distance between two lat/lon pairs in nautical miles."""
@@ -54,6 +62,11 @@ def add_waypoint():
         abort(400, description='Missing required fields')
     if not (-90 <= lat <= 90 and -180 <= lon <= 180):
         abort(400, description='Coordinates out of range')
+    if not (
+        BC_BOUNDS["min_lat"] <= lat <= BC_BOUNDS["max_lat"]
+        and BC_BOUNDS["min_lon"] <= lon <= BC_BOUNDS["max_lon"]
+    ):
+        abort(400, description='Coordinates must be within British Columbia')
     if not (-1000 <= elev <= 15000):
         abort(400, description='Elevation out of range')
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -94,3 +94,16 @@ def test_add_waypoint_invalid_lat(client):
     resp = client.post('/addWaypoint', json=payload)
     assert resp.status_code == 400
 
+
+def test_add_waypoint_outside_bc(client):
+    payload = {
+        'code': 'OUTBC',
+        'name': 'Outside BC',
+        'lat': 47.0,
+        'lon': -123.1,
+        'elev': 50,
+    }
+    resp = client.post('/addWaypoint', json=payload)
+    assert resp.status_code == 400
+    assert 'British Columbia' in resp.get_json()['error']
+


### PR DESCRIPTION
## Summary
- validate waypoint coordinates within British Columbia
- reject waypoint creation outside BC
- enforce BC bounds for scene inputs in the UI
- add tests for BC coordinate validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688373bd626883218b08c6f8dff74923