### PR TITLE
Fix PDF orientation for email attachment

### DIFF
--- a/myapp/static/route.js
+++ b/myapp/static/route.js
@@ -822,7 +822,10 @@ export async function printFlightLog() {
   const container = document.createElement("div");
   container.innerHTML = html;
   try {
-    const blob = await html2pdf().from(container).outputPdf("blob");
+    const options = {
+      jsPDF: { format: "a4", orientation: "landscape" },
+    };
+    const blob = await html2pdf().set(options).from(container).outputPdf("blob");
     const file = new File([blob], "flight-log.pdf", {
       type: "application/pdf",
     });


### PR DESCRIPTION
## Summary
- set PDF options in `printFlightLog` so html2pdf renders in landscape

## Testing
- `pip install -r myapp/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883abf5205c8321a20703393a6b6e89